### PR TITLE
Set the Travis CI domain via a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ defaults to:
 
 ### Travis CI
 
-**Pro and Enterprise not supported. Pull requests welcome!**
-
 The buffer's directory or one of its ancestors must contain a `.travis.yml` file.
 
 To set a token (but also see [`git config` tokens](#usage)):
@@ -135,10 +133,16 @@ defaults to:
   ("created" . "queued"))
 ```
 
+By default, the open source Travis CI (travis-ci.org) is used. To use the pro or
+enterprise versions, set the `build-status-travis-ci-domain` variable to
+`travis-ci.com`, or the domain of your enterprise instance. If you have projects
+in both, [directory
+variables](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html#Directory-Variables)
+are a good way to set up domain and token on a per-project basis.
+
 ## TODOs
 
 * Support for Enterprise GitHub
-* Support for TravisCI Pro and Enterprise
 * Support for VCS mode hooks
 * Support for AppVeyor
 

--- a/build-status.el
+++ b/build-status.el
@@ -50,6 +50,10 @@ The API token can also be sit via: `git config --add build-status.api-token`.")
   "Travis CI API token.
 The API token can also be sit via: `git config --add build-status.api-token`.")
 
+(defvar build-status-travis-ci-domain nil
+  "Travis CI domain.
+It can be travis-ci.org, travis-ci.com, or the domain of your own enterprise instance.")
+
 (defvar build-status-circle-ci-status-mapping-alist
   '(("infrastructure_fail" . "failed")
     ("not_running" . "queued")
@@ -200,10 +204,15 @@ If `FILENAME' is not part of a CI project return nil."
             (nth 5 project)
             (nth 6 project))))
 
+(defun build-status--travis-ci-domain ()
+  (or build-status-travis-ci-domain
+      "travis-ci.org"))
+
 (defun build-status--travis-ci-url (project)
   (let* ((json (build-status--travis-ci-branch-request project))
          (build (cdr (assq 'id (assq 'branch json)))))
-    (format "https://travis-ci.org/%s/%s/builds/%s"
+    (format "https://%s/%s/%s/builds/%s"
+            (build-status--travis-ci-domain)
             (nth 4 project)
             (nth 5 project)
             build)))
@@ -255,7 +264,8 @@ Signals an error if the response does not contain an HTTP 200 status code."
 
 (defun build-status--travis-ci-branch-request (project)
   "Get the Travis CI build status of `PROJECT'."
-  (let ((url (format "https://api.travis-ci.org/repos/%s/%s/branches/%s"
+  (let ((url (format "https://api.%s/repos/%s/%s/branches/%s"
+                     (build-status--travis-ci-domain)
                      (nth 4 project)
                      (nth 5 project)
                      (nth 6 project)))


### PR DESCRIPTION
There is no way to tell from the local `.travis.yml` file if the project is hosted on .org or .com. One could of course fallback to the other one if the first fails, but that'd be probably inefficient, and still leaves the problem of Enterprise. So I thought this would be the simpler way of doing it.

I'm successfully using my fork with several projects in .org and .com, I didn't test in enterprise though. I think it _should_ work, if you point to the right domain.

Note: While trying that this worked with different projects (I have some in .org and some in .com), I discovered a small bug, which I fixed in a separate PR for easier review: #8 (but I based this branch in that one).